### PR TITLE
Add auth to service routes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "private": true,
   "scripts": {
     "dev:simple":
-      "LOG_LEVEL=silly ts-node-dev --notify=false packages/tentales-example-simple/src/index.ts",
+      "LOG_LEVEL=silly SERVER_SECRET=superSecret ts-node-dev --notify=false packages/tentales-example-simple/src/index.ts",
     "dev:simple:check":
       "tsc -p packages/tentales-example-simple -w --pretty --strict --noEmit",
     "dev:advanced-front":
-      "LOG_LEVEL=silly nodemon --ext ts,js --exec ts-node ./packages/tentales-example-advanced/src/index.front.js",
+      "LOG_LEVEL=silly SERVER_SECRET=superSecret nodemon --ext ts,js --exec ts-node ./packages/tentales-example-advanced/src/index.front.js",
     "dev:advanced-back":
-      "LOG_LEVEL=silly nodemon --ext ts,js --exec ts-node ./packages/tentales-example-advanced/src/index.back.js",
+      "LOG_LEVEL=silly SERVER_SECRET=superSecret nodemon --ext ts,js --exec ts-node ./packages/tentales-example-advanced/src/index.back.js",
     "lint": "yarn lint:ts && yarn lint:js",
     "lint:ts": "tslint --project .",
     "lint:js": "eslint packages",
@@ -74,6 +74,8 @@
     "yarn-run-all": "^3.1.1"
   },
   "dependencies": {
+    "@types/jsonwebtoken": "^7.2.5",
+    "jsonwebtoken": "^8.1.1",
     "npmlog": "^4.1.2",
     "ramda": "^0.25.0",
     "tslint-config-prettier": "^1.8.0"

--- a/packages/tentales-example-advanced/src/index.back.js
+++ b/packages/tentales-example-advanced/src/index.back.js
@@ -4,6 +4,7 @@ const path = require("path")
 tenTales({
   port: 4001,
   public: false,
+  serverSecret: process.env.SERVER_SECRET || "",
   reactComponentsDirectory: path.join(__dirname, "components"),
   services: {
     renderer: {

--- a/packages/tentales-example-advanced/src/index.front.js
+++ b/packages/tentales-example-advanced/src/index.front.js
@@ -4,6 +4,7 @@ const path = require("path")
 tenTales({
   port: 4000,
   public: true,
+  serverSecret: process.env.SERVER_SECRET || "",
   reactComponentsDirectory: path.join(__dirname, "components"),
   services: {
     renderer: {

--- a/packages/tentales-example-simple/src/index.ts
+++ b/packages/tentales-example-simple/src/index.ts
@@ -16,6 +16,9 @@ sampleMiddleware.displayName = "Sample Middleware"
 tenTales({
   port: 4000,
   public: true,
+  auth: {
+    serverSecret: process.env.SERVER_SECRET || "",
+  },
   reactComponentsDirectory: path.join(__dirname, "components"),
   services: {
     renderer: {

--- a/packages/tentales/src/index.d.ts
+++ b/packages/tentales/src/index.d.ts
@@ -67,14 +67,14 @@ declare module "tentales" {
   /**
    * Middlewares
    */
+  interface MiddlewareProps {
+    services: Services
+    log: Log
+    config: Config
+  }
+
   export interface Middleware {
-    (
-      {
-        services,
-        log,
-        config,
-      }: { services: Services; log: Log; config: Config },
-    ): Koa.Middleware
+    (props: MiddlewareProps): Koa.Middleware
     displayName?: string
   }
 

--- a/packages/tentales/src/index.d.ts
+++ b/packages/tentales/src/index.d.ts
@@ -54,6 +54,7 @@ declare module "tentales" {
     | "beforeRenderMiddleware"
     | "renderMiddleware"
     | "afterRenderMiddleware"
+    | "protectServiceRoutesMiddleware"
     | "beforeServices"
     | "rendererService"
     | "editorService"
@@ -67,7 +68,13 @@ declare module "tentales" {
    * Middlewares
    */
   export interface Middleware {
-    ({ services, log }: { services: Services; log: Log }): Koa.Middleware
+    (
+      {
+        services,
+        log,
+        config,
+      }: { services: Services; log: Log; config: Config },
+    ): Koa.Middleware
     displayName?: string
   }
 
@@ -87,6 +94,9 @@ declare module "tentales" {
   export interface Config {
     port: number
     public: boolean
+    auth: {
+      serverSecret: string | Buffer
+    }
     reactComponentsDirectory: string
     services: { [K in ServiceName]: ServiceConfig }
     hooks?: {

--- a/packages/tentales/src/index.ts
+++ b/packages/tentales/src/index.ts
@@ -19,6 +19,7 @@ export function tenTales(config: Config): void {
 
   initiateMiddlewares({
     server,
+    config,
     services: convertServiceMethodsToServices(serviceCallers),
     hooks: [
       ...getDefaultHooks({ isPublic: config.public }),

--- a/packages/tentales/src/middleware/default-hooks.ts
+++ b/packages/tentales/src/middleware/default-hooks.ts
@@ -1,11 +1,8 @@
 import { Hook } from "tentales"
-
-import bodyParser from "koa-bodyparser"
+import { bodyParserMiddleware } from "./middlewares/body-parser-middleware"
 import { renderMiddleware } from "./middlewares/render-middleware"
 import { fourOhFourMiddleware } from "./middlewares/four-oh-four-middleware"
 import { errorMiddleware } from "./middlewares/error-middleware"
-
-const bodyParserMiddleware = () => bodyParser()
 
 const DEFAULT_HOOKS_PUBLIC: Hook[] = [
   ["errorMiddleware", [errorMiddleware]],

--- a/packages/tentales/src/middleware/default-hooks.ts
+++ b/packages/tentales/src/middleware/default-hooks.ts
@@ -3,17 +3,20 @@ import { bodyParserMiddleware } from "./middlewares/body-parser-middleware"
 import { renderMiddleware } from "./middlewares/render-middleware"
 import { fourOhFourMiddleware } from "./middlewares/four-oh-four-middleware"
 import { errorMiddleware } from "./middlewares/error-middleware"
+import { protectServiceRoutesMiddleware } from "./middlewares/protect-service-routes-middelware"
 
 const DEFAULT_HOOKS_PUBLIC: Hook[] = [
   ["errorMiddleware", [errorMiddleware]],
   ["bodyParserMiddleware", [bodyParserMiddleware]],
   ["renderMiddleware", [renderMiddleware]],
+  ["protectServiceRoutesMiddleware", [protectServiceRoutesMiddleware]],
   ["fourOhFourMiddleware", [fourOhFourMiddleware]],
 ]
 
 const DEFAULT_HOOKS_SERVICE: Hook[] = [
   ["errorMiddleware", [errorMiddleware]],
   ["bodyParserMiddleware", [bodyParserMiddleware]],
+  ["protectServiceRoutesMiddleware", [protectServiceRoutesMiddleware]],
 ]
 
 export function getDefaultHooks({ isPublic }: { isPublic: boolean }): Hook[] {

--- a/packages/tentales/src/middleware/errors.ts
+++ b/packages/tentales/src/middleware/errors.ts
@@ -1,0 +1,26 @@
+/* tslint:disable max-classes-per-file */
+
+export class TenTalesNetworkError extends Error {
+  protected status: number
+  protected expose: boolean
+
+  constructor({
+    message,
+    status = 500,
+    expose = true,
+  }: {
+    message?: string
+    status?: number
+    expose?: boolean
+  }) {
+    super(message)
+    this.status = status
+    this.expose = expose
+  }
+}
+
+export class AuthError extends TenTalesNetworkError {
+  constructor() {
+    super({ message: "Auth error", status: 401 })
+  }
+}

--- a/packages/tentales/src/middleware/initiate-middlewares.ts
+++ b/packages/tentales/src/middleware/initiate-middlewares.ts
@@ -1,16 +1,24 @@
 import { createLog } from "tentales-log"
 import Koa from "koa"
-import { Middleware, ServiceName, HookName, Services, Hook } from "tentales"
+import {
+  Middleware,
+  ServiceName,
+  HookName,
+  Services,
+  Hook,
+  Config,
+} from "tentales"
 
 const HOOKS_ORDER = [
   "beforeErrorMiddleware",
   "errorMiddleware",
   "first",
-  "beforeBodyParserMiddleware",
-  "bodyParserMiddleware",
   "beforeRenderMiddleware",
   "renderMiddleware",
   "afterRenderMiddleware",
+  "beforeBodyParserMiddleware",
+  "bodyParserMiddleware",
+  "protectServiceRoutesMiddleware",
   "beforeServices",
   "rendererService",
   "editorService",
@@ -25,10 +33,12 @@ export function initiateMiddlewares({
   hooks,
   server,
   services,
+  config,
 }: {
   hooks: Hook[]
   server: Koa
   services: Services
+  config: Config
 }): void {
   const log = createLog("TT")
   const uniqueHooks = new Map()
@@ -56,6 +66,7 @@ export function initiateMiddlewares({
         middleware({
           services,
           log: mwLog,
+          config,
         }),
       )
       mwLog.verbose("Started")

--- a/packages/tentales/src/middleware/middlewares/body-parser-middleware.ts
+++ b/packages/tentales/src/middleware/middlewares/body-parser-middleware.ts
@@ -1,0 +1,6 @@
+import bodyParser from "koa-bodyparser"
+import { Middleware } from "tentales"
+import * as Koa from "koa" // Needed for TS
+
+export const bodyParserMiddleware: Middleware = () => bodyParser()
+bodyParserMiddleware.displayName = "Body Parser"

--- a/packages/tentales/src/middleware/middlewares/error-middleware.ts
+++ b/packages/tentales/src/middleware/middlewares/error-middleware.ts
@@ -1,15 +1,42 @@
+import { createLog } from "tentales-log"
 import { Middleware } from "tentales"
+import { TenTalesNetworkError } from "../errors"
+import { both, prop, propOr, has, ifElse, always } from "ramda"
+import * as Koa from "koa"
+
+const log = createLog("TT")
+
+const getStatus: (e: Error) => number = propOr(500, "status")
+
+const getErrorMessage: (e: Error) => string = ifElse(
+  both(propOr(false, "expose"), has("message")),
+  prop("message"),
+  always("Unknown error"),
+)
+
+const isJsonRequest: (ctx: Koa.Context) => boolean = ctx =>
+  ctx.accepts("application/json") === "application/json"
 
 export const errorMiddleware: Middleware = () =>
   async function actualErrorMiddleware(ctx, next) {
     try {
       await next()
     } catch (err) {
-      ctx.status = 500
-      ctx.type = "text/html"
-      ctx.body = "Something went wrong!"
+      if (isJsonRequest(ctx)) {
+        ctx.type = "application/json"
+        ctx.body = `{ "error": ${JSON.stringify(getErrorMessage(err))} }`
+      } else {
+        ctx.type = "text/html"
+        ctx.body = getErrorMessage(err)
+      }
 
-      ctx.app.emit("error", err, ctx)
+      ctx.status = getStatus(err)
+      log.silly(err)
+
+      if (!(err instanceof TenTalesNetworkError)) {
+        log.error(err)
+        ctx.app.emit("error", err, ctx)
+      }
     }
   }
 

--- a/packages/tentales/src/middleware/middlewares/protect-service-routes-middelware.ts
+++ b/packages/tentales/src/middleware/middlewares/protect-service-routes-middelware.ts
@@ -1,0 +1,22 @@
+import { Middleware } from "tentales"
+import { isServiceRoute } from "../../utils/url"
+import { readToken } from "../../utils/token"
+import { verify } from "jsonwebtoken"
+import { AuthError } from "../errors"
+
+export const protectServiceRoutesMiddleware: Middleware = ({ config }) => {
+  return async function actualProtectServiceRoutesMiddleware(ctx, next) {
+    if (!isServiceRoute(ctx.request.URL.pathname)) {
+      await next()
+    } else {
+      try {
+        verify(readToken(ctx), config.auth.serverSecret)
+        await next()
+      } catch (_) {
+        throw new AuthError()
+      }
+    }
+  }
+}
+
+protectServiceRoutesMiddleware.displayName = "Protect Service Routes"

--- a/packages/tentales/src/service/create-service-callers.ts
+++ b/packages/tentales/src/service/create-service-callers.ts
@@ -1,6 +1,7 @@
 import fetch from "node-fetch"
 import { createLog } from "tentales-log"
 import { Action, ServiceConfig, ServiceCaller, Config } from "tentales"
+import { mintToken } from "../utils/token"
 
 // tslint:disable-next-line:no-any
 function getServiceConfig(serviceName: string, config: any): ServiceConfig {
@@ -8,6 +9,8 @@ function getServiceConfig(serviceName: string, config: any): ServiceConfig {
 }
 
 export function createServiceCallers(config: Config): ServiceCaller[] {
+  const bearer = `Bearer ${mintToken(config.auth.serverSecret)}`
+
   return Object.keys(config.services).map(serviceName => {
     const log = createLog("TT")
     const serviceConfig = getServiceConfig(serviceName, config)
@@ -22,6 +25,7 @@ export function createServiceCallers(config: Config): ServiceCaller[] {
       const response = await fetch(`${host}${serviceConfig.path}`, {
         method: "POST",
         headers: {
+          Authorization: bearer,
           Accept: "application/json",
           "Content-Type": "application/json",
         },

--- a/packages/tentales/src/utils/token.ts
+++ b/packages/tentales/src/utils/token.ts
@@ -1,0 +1,13 @@
+import * as Koa from "koa"
+import { sign } from "jsonwebtoken"
+import { pathOr, nth, defaultTo, pipe, split } from "ramda"
+
+export function mintToken(secret: string | Buffer): string {
+  return sign({}, secret)
+}
+export const readToken: (ctx: Koa.Context) => string = pipe(
+  pathOr("", ["request", "headers", "authorization"]),
+  split(" "),
+  nth(1),
+  defaultTo(""),
+)

--- a/packages/tentales/src/utils/url.ts
+++ b/packages/tentales/src/utils/url.ts
@@ -1,3 +1,5 @@
+import { startsWith } from "ramda"
+
 export function isServiceRoute(url: string): boolean {
-  return url.startsWith("/tt/") // TODO, Move to config
+  return startsWith("/tt/", url) // TODO, Move to config
 }

--- a/packages/tentales/src/utils/url.ts
+++ b/packages/tentales/src/utils/url.ts
@@ -1,0 +1,3 @@
+export function isServiceRoute(url: string): boolean {
+  return url.startsWith("/tt/") // TODO, Move to config
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,6 +113,12 @@
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.2.2.tgz#17dfe5a82184a8898935d96fe2eaedd37d22d9a4"
 
+"@types/jsonwebtoken@^7.2.5":
+  version "7.2.5"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-7.2.5.tgz#413159d570ec45fc3e7da7ea3f7bca6fb9300e72"
+  dependencies:
+    "@types/node" "*"
+
 "@types/keygrip@*":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/keygrip/-/keygrip-1.0.1.tgz#ff540462d2fb4d0a88441ceaf27d287b01c3d878"
@@ -633,6 +639,10 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base64url@2.0.0, base64url@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/base64url/-/base64url-2.0.0.tgz#eac16e03ea1438eff9423d69baa36262ed1f70bb"
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -737,6 +747,10 @@ bser@^2.0.0:
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
   dependencies:
     node-int64 "^0.4.0"
+
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
 
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
@@ -1311,6 +1325,13 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+ecdsa-sig-formatter@1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz#4bc926274ec3b5abb5016e7e1d60921ac262b2a1"
+  dependencies:
+    base64url "^2.0.0"
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -2973,6 +2994,21 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
+jsonwebtoken@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.1.1.tgz#b04d8bb2ad847bc93238c3c92170ffdbdd1cb2ea"
+  dependencies:
+    jws "^3.1.4"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    xtend "^4.0.1"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -2987,6 +3023,23 @@ jsx-ast-utils@^2.0.0, jsx-ast-utils@^2.0.1:
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:
     array-includes "^3.0.3"
+
+jwa@^1.1.4:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.1.5.tgz#a0552ce0220742cd52e153774a32905c30e756e5"
+  dependencies:
+    base64url "2.0.0"
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.9"
+    safe-buffer "^5.0.1"
+
+jws@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.1.4.tgz#f9e8b9338e8a847277d6444b1464f61880e050a2"
+  dependencies:
+    base64url "^2.0.0"
+    jwa "^1.1.4"
+    safe-buffer "^5.0.1"
 
 keygrip@~1.0.2:
   version "1.0.2"
@@ -3262,6 +3315,10 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -3270,6 +3327,26 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
@@ -3277,6 +3354,10 @@ lodash.keys@^3.0.0:
     lodash._getnative "^3.0.0"
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -3504,6 +3585,10 @@ mixin-deep@^1.2.0:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -5259,6 +5344,10 @@ xdg-basedir@^3.0.0:
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+
+xtend@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
 xtend@~2.0.6:
   version "2.0.6"


### PR DESCRIPTION
Incoming requests to the TenTales server could be one of the following: 

* A "normal" request, e.g. "www.izettle.com/gb"
* A "service" request. There are 3 services (render, data, editor) which can all be on the same server or spread out over many servers. Service-to-service communication is done over http. So e.g. when the render service is asking the data service for data. This is done via a http post to `http://data-server.com/tt/data`

This PR is adding JWT as a means of auth. When a service makes a call to another service, a server-to-server JWT is added to the header, which is then parsed and checked on the target server.