### PR TITLE
Add arbitrary options to ServiceConfig

### DIFF
--- a/packages/tentales/src/index.d.ts
+++ b/packages/tentales/src/index.d.ts
@@ -28,6 +28,7 @@ declare module "tentales" {
     host: string
     path: string
     handler?: ServiceFactory
+    options?: object
   }
 
   export interface ServiceCaller {


### PR DESCRIPTION
This would be useful in defining database options such as locations and sharding or any other imaginable option that we can't preconceive. The config is already passed to the service in question so the service implementation decides which options are respected.